### PR TITLE
fix: use default chain instead of hardcoded

### DIFF
--- a/src/resources/s3.ts
+++ b/src/resources/s3.ts
@@ -21,14 +21,6 @@ export class S3Resource {
       region: process.env.AWS_REGION || region,
     };
 
-    // Set credentials if provided in environment variables
-    if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
-      clientOptions.credentials = {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-      };
-    }
-
     // Custom endpoint configuration for MinIO
     if (process.env.AWS_ENDPOINT) {
       clientOptions.endpoint = process.env.AWS_ENDPOINT;


### PR DESCRIPTION
## Overview

Uses the default credential  chain functionality of the aws sdk to avoid having to support all the different methods of authentication.

## Changes

- removes the hardcoded credential object

## Testing

I ran the existing tests with `npm run test`, and I also ran it through mcp-inspector with `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` set.
